### PR TITLE
GitHub based plugin usage counter

### DIFF
--- a/PluginLoader/Data/GitHubPlugin.cs
+++ b/PluginLoader/Data/GitHubPlugin.cs
@@ -6,10 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Xml.Serialization;
-using VRage.Game.ModAPI;
 
 namespace avaness.PluginLoader.Data
 {
@@ -96,6 +96,7 @@ namespace avaness.PluginLoader.Data
                 Status = PluginStatus.Updated;
                 lbl.SetText($"Compiled '{FriendlyName}'");
                 a = Assembly.Load(data);
+                CountDownload(a);
             }
             else
             {
@@ -103,10 +104,27 @@ namespace avaness.PluginLoader.Data
             }
 
             Version = a.GetName().Version;
+
             return a;
         }
 
-
+        private void CountDownload(Assembly a)
+        {
+            var version = a.GetName().Version.ToString();
+            try
+            {
+                GitHub.DownloadRelease(Id, version, "README.md").Close();
+                LogFile.WriteLine($"Plugin {Id} download counted for release {version}");
+            }
+            catch (WebException e)
+            {
+                LogFile.WriteLine($"Plugin {Id} is missing release {version}, download not counted");
+            }
+            catch (Exception e)
+            {
+                LogFile.WriteLine($"Failed to count download of plugin {Id}: {e}");
+            }
+        }
 
         public byte[] CompileFromSource(Action<float> callback = null)
         {

--- a/PluginLoader/Data/PluginData.cs
+++ b/PluginLoader/Data/PluginData.cs
@@ -65,6 +65,8 @@ namespace avaness.PluginLoader.Data
         [XmlIgnore]
         public List<PluginData> Group { get; } = new List<PluginData>();
 
+        [XmlIgnore] public int? Usage { get; protected set; }
+
         protected PluginData()
         {
 

--- a/PluginLoader/Network/GitHub.cs
+++ b/PluginLoader/Network/GitHub.cs
@@ -14,11 +14,12 @@ namespace avaness.PluginLoader.Network
         private const string repoZipUrl = "https://github.com/{0}/archive/{1}.zip";
         private const string rawUrl = "https://raw.githubusercontent.com/{0}/{1}/";
         private const string releaseUrl = "https://github.com/{0}/releases/download/{1}/{2}";
+        private const string reposApiUrl = "https://api.github.com/repos/{0}/{1}";
 
         public static Stream DownloadRepo(string name, string commit, out string fileName)
         {
             Uri uri = new Uri(string.Format(repoZipUrl, name, commit), UriKind.Absolute);
-            HttpWebResponse response = Download(uri);
+            HttpWebResponse response = Download(uri, 60000);
             GetFileNameFromHeader(response, out fileName);
             return response.GetResponseStream();
         }
@@ -26,22 +27,33 @@ namespace avaness.PluginLoader.Network
         public static Stream DownloadFile(string name, string commit, string path)
         {
             Uri uri = new Uri(string.Format(rawUrl, name, commit) + path.TrimStart('/'), UriKind.Absolute);
-            HttpWebResponse response = Download(uri);
+            HttpWebResponse response = Download(uri, 60000);
             return response.GetResponseStream();
         }
 
         public static Stream DownloadRelease(string name, string tag, string filename)
         {
             Uri uri = new Uri(string.Format(releaseUrl, name, tag, filename), UriKind.Absolute);
-            HttpWebResponse response = Download(uri);
+            HttpWebResponse response = Download(uri, 3000);
             return response.GetResponseStream();
         }
 
-        private static HttpWebResponse Download(Uri uri)
+        public static Stream DownloadReposApi(string name, string path)
+        {
+            Uri uri = new Uri(string.Format(reposApiUrl, name, path), UriKind.Absolute);
+            HttpWebResponse response = Download(uri, 3000, true);
+            return response.GetResponseStream();
+        }
+
+        private static HttpWebResponse Download(Uri uri, int timeoutMs = 60000, bool json = false)
         {
             LogFile.WriteLine("Downloading " + uri);
             HttpWebRequest request = WebRequest.CreateHttp(uri);
+            request.Timeout = timeoutMs;
             request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            request.UserAgent = "austinvaness/PluginLoader";
+            if (json)
+                request.Accept = "application/json";
             HttpWebResponse response = (HttpWebResponse)request.GetResponse();
             return response;
         }

--- a/PluginLoader/Network/GitHub.cs
+++ b/PluginLoader/Network/GitHub.cs
@@ -13,39 +13,51 @@ namespace avaness.PluginLoader.Network
 
         private const string repoZipUrl = "https://github.com/{0}/archive/{1}.zip";
         private const string rawUrl = "https://raw.githubusercontent.com/{0}/{1}/";
+        private const string releaseUrl = "https://github.com/{0}/releases/download/{1}/{2}";
 
         public static Stream DownloadRepo(string name, string commit, out string fileName)
         {
             Uri uri = new Uri(string.Format(repoZipUrl, name, commit), UriKind.Absolute);
-            LogFile.WriteLine("Downloading " + uri);
-            HttpWebRequest request = WebRequest.CreateHttp(uri);
-            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-            fileName = response.Headers["Content-Disposition"];
-            if(fileName != null)
-            {
-                int index = fileName.IndexOf("filename=");
-                if(index >= 0)
-                {
-                    index += "filename=".Length;
-                    fileName = fileName.Substring(index).Trim('"');
-                }
-            }
-
+            HttpWebResponse response = Download(uri);
+            GetFileNameFromHeader(response, out fileName);
             return response.GetResponseStream();
         }
 
         public static Stream DownloadFile(string name, string commit, string path)
         {
             Uri uri = new Uri(string.Format(rawUrl, name, commit) + path.TrimStart('/'), UriKind.Absolute);
-            LogFile.WriteLine("Downloading " + uri);
-            HttpWebRequest request = WebRequest.CreateHttp(uri);
-            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+            HttpWebResponse response = Download(uri);
             return response.GetResponseStream();
         }
 
+        public static Stream DownloadRelease(string name, string tag, string filename)
+        {
+            Uri uri = new Uri(string.Format(releaseUrl, name, tag, filename), UriKind.Absolute);
+            HttpWebResponse response = Download(uri);
+            return response.GetResponseStream();
+        }
+
+        private static HttpWebResponse Download(Uri uri)
+        {
+            LogFile.WriteLine("Downloading " + uri);
+            HttpWebRequest request = WebRequest.CreateHttp(uri);
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+            return response;
+        }
+
+        private static void GetFileNameFromHeader(HttpWebResponse response, out string fileName)
+        {
+            fileName = response.Headers["Content-Disposition"];
+            if (fileName == null)
+                return;
+
+            int index = fileName.IndexOf("filename=", StringComparison.InvariantCulture);
+            if (index < 0)
+                return;
+
+            index += "filename=".Length;
+            fileName = fileName.Substring(index).Trim('"');
+        }
     }
 }


### PR DESCRIPTION
Using GitHub's release file download counters to track plugin usage (compilations) on clients. No separate hosting required.

For example this release:
https://github.com/viktor-ferenczi/toolbar-manager/releases/tag/1.2.0.0

Is counted by downloading file after successful source download and compilation (very short delay for compiled plugins only):
https://github.com/viktor-ferenczi/toolbar-manager/releases/tag/1.2.0.0/README.md

Plugin developer must have a release for the latest version on the PluginHub for the counter to work. Otherwise the counter will disappear from the list (cannot be incremented, nor downloaded). This is what we pay for not having to host it. These readme files are actually useful to instruct people why there is no binary release of these plugins.

The counter is available from GitHub API:
https://api.github.com/repos/viktor-ferenczi/toolbar-manager/releases

JSON is filtered for entries by **name** or **tag_name**, then assets for file name **README.md** (exact match, case sensitive).

Usage counts of the enabled GitHub plugins are downloaded once on Plugin Loader startup in a background thread, so no slowdown in game startup. The download needs the assembly version, so it is not possible to download the counts for the plugins which are not loaded.

Q: Why we don't count the source ZIP downloads?
A: Because GitHub stopped counting them many years ago.

Q: Is the GitHub API rate limited?
A: Yes, it is: [GitHub API rate limits](https://docs.github.com/en/rest/reference/rate-limit) - We will need to have caching of usage values once a player can have more than 60 plugins active at a time.