### PR TITLE
Requesting consent on first voting attempt

### DIFF
--- a/PluginLoader/GUI/GuiControls/PluginDetails.cs
+++ b/PluginLoader/GUI/GuiControls/PluginDetails.cs
@@ -102,8 +102,8 @@ namespace avaness.PluginLoader.GUI.GuiControls
         public void LoadPluginData()
         {
             var stat = PluginStat;
-            var tried = stat.Tried;
             var vote = stat.Vote;
+            var canVote = plugin.Enabled || stat.Tried;
 
             pluginNameText.Text = plugin.FriendlyName ?? "N/A";
 
@@ -113,17 +113,17 @@ namespace avaness.PluginLoader.GUI.GuiControls
 
             statusText.Text = plugin.Status == PluginStatus.None ? (plugin.Enabled ? "Up to date" : "N/A") : plugin.StatusString;
 
-            usageText.Text = stat.Players.ToString() ?? "N/A";
+            usageText.Text = stat.Players.ToString();
 
             ratingControl.Value = stat.Rating;
             ratingText.Text = $"{stat.Downvotes + stat.Upvotes}";
 
-            upvoteIcon.Visible = tried;
-            upvoteButton.Visible = tried;
+            upvoteIcon.Visible = canVote;
+            upvoteButton.Visible = canVote;
             upvoteButton.Checked = vote > 0;
 
-            downvoteIcon.Visible = tried;
-            downvoteButton.Visible = tried;
+            downvoteIcon.Visible = canVote;
+            downvoteButton.Visible = canVote;
             downvoteButton.Checked = vote < 0;
 
             descriptionText.Text.Clear().Append(plugin.Tooltip ?? "");
@@ -348,11 +348,16 @@ namespace avaness.PluginLoader.GUI.GuiControls
 
         private void Vote(int vote)
         {
-            if (!PlayerConsent.HasConsentRequested)
-            {
-                PlayerConsent.ShowDialog();
+            if (PlayerConsent.ConsentGiven)
+                StoreVote(vote);
+            else
+                PlayerConsent.ShowDialog(() => StoreVote(vote));
+        }
+
+        private void StoreVote(int vote)
+        {
+            if (!PlayerConsent.ConsentGiven)
                 return;
-            }
 
             var originalStat = PluginStat;
             if (originalStat.Vote == vote)

--- a/PluginLoader/GUI/MyGuiScreenPluginConfig.cs
+++ b/PluginLoader/GUI/MyGuiScreenPluginConfig.cs
@@ -117,7 +117,6 @@ namespace avaness.PluginLoader.GUI
         private void OnConsentChanged()
         {
             PluginStats = StatsClient.DownloadStats();
-            RefreshTable();
             pluginDetails.LoadPluginData();
         }
 
@@ -222,7 +221,8 @@ namespace avaness.PluginLoader.GUI
             // Adds buttons at bottom of menu
             var buttonRestart = new MyGuiControlButton(origin, MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Restart the game and apply changes.", new StringBuilder("Apply"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnRestartButtonClick);
             var buttonClose = new MyGuiControlButton(origin, MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Closes the dialog without saving changes to plugin selection", new StringBuilder("Cancel"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnCancelButtonClick);
-            var buttonConsent = new MyGuiControlButton(origin, PlayerConsent.HasConsentGiven ? MyGuiControlButtonStyleEnum.Tiny : MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Give or withdraw your consent for data handling", new StringBuilder(PlayerConsent.HasConsentGiven ? "..." : "Consent"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnConsentButtonClick);
+            var buttonConsent = new MyGuiControlButton(origin, PlayerConsent.ConsentGiven ? MyGuiControlButtonStyleEnum.Tiny : MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Give or withdraw your consent for data handling", new StringBuilder(PlayerConsent.ConsentGiven ? "..." : "Consent"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnConsentButtonClick);
+            buttonConsent.Visible = PlayerConsent.ConsentGiven;
 
             // FIXME: Use MyLayoutHorizontal instead
             AlignRow(origin + new Vector2(0.1f, 0f), 0.05f, buttonRestart, buttonClose, buttonConsent);
@@ -450,9 +450,6 @@ namespace avaness.PluginLoader.GUI
 
             if (enable)
                 DisableOtherPluginsInSameGroup(plugin);
-
-            if (enable && !PlayerConsent.HasConsentRequested)
-                PlayerConsent.ShowDialog();
         }
 
         private void SetPluginCheckbox(PluginData plugin, bool enable)
@@ -481,7 +478,7 @@ namespace avaness.PluginLoader.GUI
             PlayerConsent.ShowDialog();
         }
 
-        public int ModifiedCount => Main.Instance.List.Count(plugin => plugin.Enabled != AfterRebootEnableFlags[plugin.Id]);
+        private int ModifiedCount => Main.Instance.List.Count(plugin => plugin.Enabled != AfterRebootEnableFlags[plugin.Id]);
 
         private void OnRestartButtonClick(MyGuiControlButton btn)
         {

--- a/PluginLoader/GUI/MyGuiScreenPluginConfig.cs
+++ b/PluginLoader/GUI/MyGuiScreenPluginConfig.cs
@@ -221,8 +221,7 @@ namespace avaness.PluginLoader.GUI
             // Adds buttons at bottom of menu
             var buttonRestart = new MyGuiControlButton(origin, MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Restart the game and apply changes.", new StringBuilder("Apply"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnRestartButtonClick);
             var buttonClose = new MyGuiControlButton(origin, MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Closes the dialog without saving changes to plugin selection", new StringBuilder("Cancel"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnCancelButtonClick);
-            var buttonConsent = new MyGuiControlButton(origin, PlayerConsent.ConsentGiven ? MyGuiControlButtonStyleEnum.Tiny : MyGuiControlButtonStyleEnum.Default, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Give or withdraw your consent for data handling", new StringBuilder(PlayerConsent.ConsentGiven ? "..." : "Consent"), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnConsentButtonClick);
-            buttonConsent.Visible = PlayerConsent.ConsentGiven;
+            var buttonConsent = new MyGuiControlButton(origin, MyGuiControlButtonStyleEnum.Tiny, null, null, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP, "Give or withdraw your consent for data handling", new StringBuilder("..."), 0.8f, MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER, MyGuiControlHighlightType.WHEN_ACTIVE, OnConsentButtonClick);
 
             // FIXME: Use MyLayoutHorizontal instead
             AlignRow(origin + new Vector2(0.1f, 0f), 0.05f, buttonRestart, buttonClose, buttonConsent);

--- a/PluginLoader/Main.cs
+++ b/PluginLoader/Main.cs
@@ -88,7 +88,7 @@ namespace avaness.PluginLoader
 
         private void ReportEnabledPlugins()
         {
-            if (!PlayerConsent.HasConsentGiven)
+            if (!PlayerConsent.ConsentGiven)
                 return;
 
             Splash.SetText("Reporting plugin usage...");


### PR DESCRIPTION
- Requesting player consent for data handling on first attempt to vote on a plugin
- Cleanup of player consent dialog logic, introduced continuation executed after the dialog is closed, unless canceled