### PR TITLE
Stats server logging and repeated consent fixes

### DIFF
--- a/PluginLoader/Stats/StatsClient.cs
+++ b/PluginLoader/Stats/StatsClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using avaness.PluginLoader.GUI;
 using avaness.PluginLoader.Stats.Model;
 using avaness.PluginLoader.Tools;
 
@@ -44,9 +45,17 @@ namespace avaness.PluginLoader.Stats
 
         public static PluginStats DownloadStats()
         {
+
+            if (!PlayerConsent.ConsentGiven)
+            {
+                LogFile.WriteLine($"Downloading plugin statistics anonymously (it does not allow for voting)");
+                votingToken = null;
+                return SimpleHttpClient.Get<PluginStats>(StatsUri);
+            }
+
             LogFile.WriteLine($"Downloading plugin statistics, ratings and votes for " + PlayerHash);
 
-            var parameters = new Dictionary<string, string> { ["playerHash"] = PlayerHash };
+            var parameters = new Dictionary<string, string> {["playerHash"] = PlayerHash};
             var pluginStats = SimpleHttpClient.Get<PluginStats>(StatsUri, parameters);
 
             votingToken = pluginStats?.VotingToken;

--- a/PluginLoader/Tools/SimpleHttpClient.cs
+++ b/PluginLoader/Tools/SimpleHttpClient.cs
@@ -38,8 +38,9 @@ namespace avaness.PluginLoader.Tools
         public static TV Get<TV>(string url, Dictionary<string, string> parameters)
             where TV : class, new()
         {
-            var query = FormatQuery(parameters);
-            var uri = $"{url}?{query}";
+            var uriBuilder = new StringBuilder(url);
+            AppendQueryParameters(uriBuilder, parameters);
+            var uri = uriBuilder.ToString();
 
             try
             {
@@ -78,8 +79,10 @@ namespace avaness.PluginLoader.Tools
         public static TV Post<TV>(string url, Dictionary<string, string> parameters)
             where TV : class, new()
         {
-            var query = FormatQuery(parameters);
-            var uri = $"{url}?{query}";
+            var uriBuilder = new StringBuilder(url);
+            AppendQueryParameters(uriBuilder, parameters);
+            var uri = uriBuilder.ToString();
+
             try
             {
                 var request = CreateRequest(HttpMethod.Post, uri);
@@ -174,8 +177,20 @@ namespace avaness.PluginLoader.Tools
             return http;
         }
 
-        private static string FormatQuery(Dictionary<string, string> parameters) =>
-            string.Join("&", parameters.Select(
-                p => $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value)}"));
+        private static void AppendQueryParameters(StringBuilder stringBuilder, Dictionary<string, string> parameters)
+        {
+            if (parameters == null || parameters.Count == 0)
+                return;
+
+            var first = true;
+            foreach (var p in parameters)
+            {
+                stringBuilder.Append(first ? '?' : '&');
+                first = false;
+                stringBuilder.Append(Uri.EscapeDataString(p.Key));
+                stringBuilder.Append('=');
+                stringBuilder.Append(Uri.EscapeDataString(p.Value));
+            }
+        }
     }
 }

--- a/StatsServer/Hosting/backup.sh
+++ b/StatsServer/Hosting/backup.sh
@@ -14,7 +14,7 @@ FILENAME="PluginLoaderStatsData.${TODAY}.zip"
 rclone copy "${FILENAME}" "${PL_BACKUP_REMOTE_NAME}:${PL_BACKUP_REMOTE_DIR}/"
 rm "${FILENAME}"
 
-# Remove old backups only the the latest backup above succeeded (otherwise this script has failed already)
+# Remove old backups only once a new backup is succeeded (otherwise this script has failed already)
 # It is normal for this step to fail until we have enough past backups to have something to delete.
 #REMOVE_DATE=$(date -I --date="yesterday")
 REMOVE_DATE=$(date -I --date="a week ago")

--- a/StatsServer/Hosting/cleanup.sh
+++ b/StatsServer/Hosting/cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "---"
+date -Is
+echo "---"
+
+. $HOME/bin/env.sh
+
+# Remove old log files
+cd "$PL_LOG_DIR"
+for FN in $(find . -mtime +60 | grep '.jsonl'); do
+	echo "Removing: $FN"
+done
+
+# Compress past log files
+TODAY=$(date -I)
+for FN in $(find . | egrep '.jsonl$' | grep -v $TODAY); do
+	echo "Compressing: $FN"
+	nice gzip -9 $FN
+done

--- a/StatsServer/Hosting/crontab
+++ b/StatsServer/Hosting/crontab
@@ -13,3 +13,7 @@ PATH="/home/stats/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 # Backup
 # mm hh         dom mon dow command
 02 01            *   *   *  /bin/bash $HOME/bin/backup.sh >>$HOME/log/backup.log 2>&1
+
+# Cleanup
+# mm hh         dom mon dow command
+32 01            *   *   *  /bin/bash $HOME/bin/cleanup.sh >>$HOME/log/cleanup.log 2>&1

--- a/StatsServer/Hosting/env.sh
+++ b/StatsServer/Hosting/env.sh
@@ -10,3 +10,5 @@ export PL_TIMEOUT=3
 
 export PL_BACKUP_REMOTE_NAME=drive
 export PL_BACKUP_REMOTE_DIR=PluginLoaderBackups
+
+export ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS=true

--- a/StatsServer/Hosting/start.sh
+++ b/StatsServer/Hosting/start.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 TODAY=$(date -I)
 
 cd "$PL_SERVER_DIR"
-dotnet StatsServer.dll >>"${PL_LOG_DIR}/${TODAY}.log" 2>&1 &
+dotnet StatsServer.dll >>"${PL_LOG_DIR}/${TODAY}.jsonl" 2>&1 &

--- a/StatsServer/Persistence/PlayerConsents.cs
+++ b/StatsServer/Persistence/PlayerConsents.cs
@@ -37,6 +37,9 @@ namespace avaness.StatsServer.Persistence
 
         public void Register(string playerHash, bool consent)
         {
+            if (consent == playerConsents.ContainsKey(playerHash))
+                return;
+
             if (consent)
             {
                 playerConsents[playerHash] = Tools.Tools.FormatDateIso8601(DateTime.Today);

--- a/StatsServer/Server.cs
+++ b/StatsServer/Server.cs
@@ -3,6 +3,7 @@ using avaness.StatsServer.Persistence;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace avaness.StatsServer
 {
@@ -17,6 +18,19 @@ namespace avaness.StatsServer
         private static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); })
+                .ConfigureLogging(builder => builder.AddJsonConsole(options =>
+                {
+                    options.IncludeScopes = false;
+                    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff";
+                    options.JsonWriterOptions = new JsonWriterOptions
+                    {
+#if DEBUG
+                        Indented = true
+#else
+                        Indented = false
+#endif
+                    };
+                }))
                 .ConfigureServices(services =>
                 {
                     services.AddHostedService<PersistenceService>();

--- a/StatsServer/appsettings.Development.json
+++ b/StatsServer/appsettings.Development.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   }

--- a/StatsServer/appsettings.json
+++ b/StatsServer/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },


### PR DESCRIPTION
- Fixed providing consent again after losing the local config.xml file (game reinstall, etc.)
- JSON logging with ISO standard date-time format. Log compression and cleanup after 60 days.
- Keep the original consent date if the user provides consent again.
- Enabled basic request logging for diagnostics purposes.